### PR TITLE
Use direct MLS warp on ROI

### DIFF
--- a/gstmozzamp/gstmozzamp.cpp
+++ b/gstmozzamp/gstmozzamp.cpp
@@ -648,7 +648,9 @@ static GstFlowReturn gst_mozza_mp_transform_frame_ip(GstVideoFilter* vf,
                          cv::INTER_LINEAR, cv::BORDER_REFLECT_101);
         } else {
           // Run MLS in-place on 3-channel ROI
-          compute_MLS_on_ROI(roi_bgr, *self->mls, src_rel, dst_rel);
+          cv::Mat warped = self->mls->setAllAndGenerate(
+              roi_bgr, src_rel, dst_rel, roi_bgr.cols, roi_bgr.rows);
+          if (!warped.empty()) warped.copyTo(roi_bgr);
         }
 
         // Delta measurement


### PR DESCRIPTION
## Summary
- Replace `compute_MLS_on_ROI` with a direct `setAllAndGenerate` call to warp ROI data in place before reconverting to RGBA.

## Testing
- `make test` *(fails: No rule to make target 'test')*
- `make` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_68a482b55418832ca9c0ddef3ca5830a