### PR TITLE
Cache BGR buffer for MLS warp

### DIFF
--- a/gstmozzamp/gstmozzamp.cpp
+++ b/gstmozzamp/gstmozzamp.cpp
@@ -75,6 +75,7 @@ struct _GstMozzaMp {
   MpFaceCtx* mp_ctx;
   std::optional<Deformations> dfm;
   std::unique_ptr<ImgWarp_MLS_Rigid> mls;
+  cv::Mat bgr_tmp;
 
   // stats
   guint64 frame_count;
@@ -553,7 +554,10 @@ static GstFlowReturn gst_mozza_mp_transform_frame_ip(GstVideoFilter* vf,
 
       const auto t0w = std::chrono::steady_clock::now();
 
-      cv::Mat img_bgr;
+      // ImgWarp_MLS_Rigid only handles 3-channel images; cache a reusable
+      // BGR buffer to avoid reallocating every frame.
+      cv::Mat& img_bgr = self->bgr_tmp;
+      img_bgr.create(H, W, CV_8UC3);
       cv::cvtColor(img_rgba, img_bgr, cv::COLOR_RGBA2BGR);
 
       for (size_t g = 0; g < srcGroups.size(); ++g) {


### PR DESCRIPTION
## Summary
- Reuse a BGR `cv::Mat` buffer for ImgWarp_MLS_Rigid since the warp library only supports 3-channel data.
- Convert between RGBA and BGR using the cached buffer to avoid per-frame allocations.

## Testing
- `pkg-config --cflags gstreamer-1.0 opencv4` *(fails: Package gstreamer-1.0 was not found)*
- `g++ -std=c++17 -c gstmozzamp/gstmozzamp.cpp` *(fails: fatal error: gst/gst.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4963e3540832cadce8aa5d94cb57d