### PR TITLE
chore: gate imgwarp debug logs behind env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,19 @@ docker run --rm -it mozzamp:latest \
 ```
 You should see properties: model, max-faces, draw, radius, color.
 
+## ImgWarp debug logs
+
+The underlying ImgWarp library can emit verbose diagnostics. These logs are
+disabled by default. To enable them, set the `IMGWARP_DEBUG` environment
+variable to a non-zero value before running any GStreamer command, for example:
+
+```bash
+IMGWARP_DEBUG=1 gst-launch-1.0 ...
+```
+
+The messages are written to standard error and can help troubleshoot warping
+issues.
+
 ## Get the .task model
 ```
 chmod +x download_face_landmarker_model.sh

--- a/imgwarp/imgwarp_mls.cpp
+++ b/imgwarp/imgwarp_mls.cpp
@@ -1,19 +1,18 @@
 #include "imgwarp_mls.h"
 #include <cstdio>
+#include <cstdlib>
 #include <cmath>
 #include <limits>
 
 using cv::Vec3b;
 
-// Small helper: env flag to toggle diagnostics - Change when debuging is done
+// Small helper: env flag to toggle diagnostics (set IMGWARP_DEBUG=1)
 static inline bool IMGWARP_DIAG() {
-  static int on = 1;
-  // Uncomment the following to make this printing accessible through an env var
-  //static int on = -1;
-  //if (on == -1) {
-  //  const char* e = std::getenv("IMGWARP_DEBUG");
-  //  on = (e && *e && e[0] != '0') ? 1 : 0;
-  // }
+  static int on = -1;
+  if (on == -1) {
+    const char* e = std::getenv("IMGWARP_DEBUG");
+    on = (e && *e && e[0] != '0') ? 1 : 0;
+  }
   return on == 1;
 }
 


### PR DESCRIPTION
## Summary
- disable always-on imgwarp diagnostics
- add `IMGWARP_DEBUG` env var to re-enable detailed imgwarp logs
- document how to access these debug logs in README

## Testing
- `g++ -std=c++17 -c imgwarp/imgwarp_mls.cpp -Iimgwarp` *(fails: opencv2/opencv.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a49bf326e8832cb1d6a3788f8ac142