### PR TITLE
Handle RGBA frames directly in mozza_mp warp

### DIFF
--- a/imgwarp/imgwarp_mls.cpp
+++ b/imgwarp/imgwarp_mls.cpp
@@ -5,6 +5,7 @@
 #include <limits>
 
 using cv::Vec3b;
+using cv::Vec4b;
 
 // Small helper: env flag to toggle diagnostics (set IMGWARP_DEBUG=1)
 static inline bool IMGWARP_DIAG() {
@@ -161,14 +162,13 @@ Mat ImgWarp_MLS::genNewImg(const Mat &oriImg, double transRatio) {
                     nxi1 = std::ceil(nx);
                     nyi1 = std::ceil(ny);
 
-                    if (oriImg.channels() == 1)
+                    if (oriImg.channels() == 1) {
                         newImg.at<uchar>(i + di, j + dj) = bilinear_interp(
                             ny - nyi, nx - nxi, oriImg.at<uchar>(nyi, nxi),
                             oriImg.at<uchar>(nyi, nxi1),
                             oriImg.at<uchar>(nyi1, nxi),
                             oriImg.at<uchar>(nyi1, nxi1));
-                    else {
-                        // NOTE: library only handles 3-channel in this branch; callers should pass BGR.
+                    } else if (oriImg.channels() == 3) {
                         for (int ll = 0; ll < 3; ll++)
                             newImg.at<Vec3b>(i + di, j + dj)[ll] =
                                 bilinear_interp(
@@ -177,6 +177,15 @@ Mat ImgWarp_MLS::genNewImg(const Mat &oriImg, double transRatio) {
                                     oriImg.at<Vec3b>(nyi, nxi1)[ll],
                                     oriImg.at<Vec3b>(nyi1, nxi)[ll],
                                     oriImg.at<Vec3b>(nyi1, nxi1)[ll]);
+                    } else if (oriImg.channels() == 4) {
+                        for (int ll = 0; ll < 4; ll++)
+                            newImg.at<Vec4b>(i + di, j + dj)[ll] =
+                                bilinear_interp(
+                                    ny - nyi, nx - nxi,
+                                    oriImg.at<Vec4b>(nyi, nxi)[ll],
+                                    oriImg.at<Vec4b>(nyi, nxi1)[ll],
+                                    oriImg.at<Vec4b>(nyi1, nxi)[ll],
+                                    oriImg.at<Vec4b>(nyi1, nxi1)[ll]);
                     }
                 }
         }


### PR DESCRIPTION
## Summary
- Extend ImgWarp_MLS to warp 4‑channel RGBA images
- Warp RGBA buffers directly in mozza_mp and drop costly color conversions

## Testing
- `g++ -std=c++17 -I/usr/include/opencv4 -c imgwarp/imgwarp_mls.cpp imgwarp/imgwarp_mls_rigid.cpp imgwarp/imgwarp_piecewiseaffine.cpp` *(fails: opencv2/opencv.hpp: No such file or directory)*
- `pkg-config --cflags --libs gstreamer-1.0 opencv4` *(fails: Package gstreamer-1.0, opencv4 not found)*
- `g++ -std=c++17 gstmozzamp/gstmozzamp.cpp -c` *(fails: gst/gst.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a508a728832c93bd6244fb3074cc