### PR TITLE
Use live-stream running mode for face landmarker

### DIFF
--- a/gstshared/mp_runtime.cc
+++ b/gstshared/mp_runtime.cc
@@ -1,59 +1,68 @@
 // gstshared/mp_runtime.cc
 #include "mp_runtime.h"
 
+#include <algorithm>
+#include <condition_variable>
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
-#include <algorithm>
 
 // MediaPipe / Tasks
 #include "absl/status/statusor.h"
 #include "mediapipe/framework/formats/image.h"
 #include "mediapipe/framework/formats/image_frame.h"
+#include "mediapipe/tasks/cc/components/containers/landmark.h"
 #include "mediapipe/tasks/cc/core/base_options.h"
 #include "mediapipe/tasks/cc/vision/core/running_mode.h"
-#include "mediapipe/tasks/cc/components/containers/landmark.h"
 #include "mediapipe/tasks/cc/vision/face_landmarker/face_landmarker.h"
 #include "mediapipe/tasks/cc/vision/face_landmarker/face_landmarker_result.h"
 
-
 using mediapipe::Image;
-using mediapipe::ImageFrame;
 using mediapipe::ImageFormat;
-namespace mp_core   = ::mediapipe::tasks::core;
+using mediapipe::ImageFrame;
+namespace mp_core = ::mediapipe::tasks::core;
 namespace mp_vision = ::mediapipe::tasks::vision;
-namespace mp_face   = ::mediapipe::tasks::vision::face_landmarker;
+namespace mp_face = ::mediapipe::tasks::vision::face_landmarker;
+namespace mp_tasks = ::mediapipe::tasks;
 
 struct MpFaceCtx {
   std::unique_ptr<mp_face::FaceLandmarker> landmarker;
   int num_faces = 1;
+  std::mutex mutex;
+  std::condition_variable cv;
+  absl::StatusOr<mp_face::FaceLandmarkerResult> pending_result;
+  bool result_ready = false;
 };
 
 // ---------- Version / build ----------
 static int rt_version() { return 10002; } // arbitrary
-static const char* rt_build() { return "mp_runtime (MediaPipe Tasks) 1.0"; }
+static const char *rt_build() { return "mp_runtime (MediaPipe Tasks) 1.0"; }
 
 // ---------- Helpers ----------
-static std::shared_ptr<ImageFrame> make_imageframe_from_mp(const MpImage* img) {
-  if (!img || !img->data || img->width <= 0 || img->height <= 0) return nullptr;
+static std::shared_ptr<ImageFrame> make_imageframe_from_mp(const MpImage *img) {
+  if (!img || !img->data || img->width <= 0 || img->height <= 0)
+    return nullptr;
 
   const int W = img->width;
   const int H = img->height;
   const int stride = img->stride;
 
   if (img->format == MP_IMAGE_RGBA8888) {
-    auto frame = std::make_shared<ImageFrame>(ImageFormat::SRGBA, W, H, /*alignment*/1);
-    uint8_t* dst = frame->MutablePixelData();
+    auto frame =
+        std::make_shared<ImageFrame>(ImageFormat::SRGBA, W, H, /*alignment*/ 1);
+    uint8_t *dst = frame->MutablePixelData();
     const int rowbytes = W * 4;
     for (int y = 0; y < H; ++y) {
       std::memcpy(dst + y * rowbytes, img->data + y * stride, rowbytes);
     }
     return frame;
   } else if (img->format == MP_IMAGE_RGB888) {
-    auto frame = std::make_shared<ImageFrame>(ImageFormat::SRGB, W, H, /*alignment*/1);
-    uint8_t* dst = frame->MutablePixelData();
+    auto frame =
+        std::make_shared<ImageFrame>(ImageFormat::SRGB, W, H, /*alignment*/ 1);
+    uint8_t *dst = frame->MutablePixelData();
     const int rowbytes = W * 3;
     for (int y = 0; y < H; ++y) {
       std::memcpy(dst + y * rowbytes, img->data + y * stride, rowbytes);
@@ -61,16 +70,17 @@ static std::shared_ptr<ImageFrame> make_imageframe_from_mp(const MpImage* img) {
     return frame;
   } else if (img->format == MP_IMAGE_GRAY8) {
     // Expand gray → SRGB
-    auto frame = std::make_shared<ImageFrame>(ImageFormat::SRGB, W, H, /*alignment*/1);
-    uint8_t* dst = frame->MutablePixelData();
+    auto frame =
+        std::make_shared<ImageFrame>(ImageFormat::SRGB, W, H, /*alignment*/ 1);
+    uint8_t *dst = frame->MutablePixelData();
     for (int y = 0; y < H; ++y) {
-      const uint8_t* src = img->data + y * stride;
-      uint8_t* drow = dst + y * (W * 3);
+      const uint8_t *src = img->data + y * stride;
+      uint8_t *drow = dst + y * (W * 3);
       for (int x = 0; x < W; ++x) {
         uint8_t v = src[x];
-        drow[3*x+0] = v;
-        drow[3*x+1] = v;
-        drow[3*x+2] = v;
+        drow[3 * x + 0] = v;
+        drow[3 * x + 1] = v;
+        drow[3 * x + 2] = v;
       }
     }
     return frame;
@@ -79,30 +89,42 @@ static std::shared_ptr<ImageFrame> make_imageframe_from_mp(const MpImage* img) {
   return nullptr;
 }
 
-static void free_result_owned(MpFaceResult* out) {
-  if (!out || !out->faces || out->faces_count <= 0) return;
+static void free_result_owned(MpFaceResult *out) {
+  if (!out || !out->faces || out->faces_count <= 0)
+    return;
   for (int i = 0; i < out->faces_count; ++i) {
-    const MpFace* f = &out->faces[i];
+    const MpFace *f = &out->faces[i];
     if (f->landmarks && f->landmarks_count > 0) {
-      free((void*)f->landmarks);
+      free((void *)f->landmarks);
     }
     // no blendshapes allocated in this minimal impl
   }
-  free((void*)out->faces);
+  free((void *)out->faces);
   out->faces = nullptr;
   out->faces_count = 0;
 }
 
 // ---------- API impl ----------
-static int rt_face_create(const MpFaceLandmarkerOptions* opts, MpFaceCtx** out) {
-  if (!out || !opts || !opts->model_path || !*opts->model_path) return -1;
+static int rt_face_create(const MpFaceLandmarkerOptions *opts,
+                          MpFaceCtx **out) {
+  if (!out || !opts || !opts->model_path || !*opts->model_path)
+    return -1;
 
   auto ctx = std::make_unique<MpFaceCtx>();
 
   auto options = std::make_unique<mp_face::FaceLandmarkerOptions>();
   options->base_options = mp_core::BaseOptions();
   options->base_options.model_asset_path = std::string(opts->model_path);
-  options->running_mode = mp_vision::core::RunningMode::VIDEO;  // expects timestamps in ms
+  options->running_mode =
+      mp_vision::core::RunningMode::LIVE_STREAM; // expects timestamps in ms
+  options->result_callback =
+      [ctx_ptr = ctx.get()](absl::StatusOr<mp_face::FaceLandmarkerResult> res,
+                            const Image &, int64_t) {
+        std::lock_guard<std::mutex> lock(ctx_ptr->mutex);
+        ctx_ptr->pending_result = std::move(res);
+        ctx_ptr->result_ready = true;
+        ctx_ptr->cv.notify_one();
+      };
   options->num_faces = std::max(1, opts->max_faces);
   options->output_face_blendshapes = (opts->with_blendshapes != 0);
   options->output_facial_transformation_matrixes = (opts->with_geometry != 0);
@@ -120,8 +142,10 @@ static int rt_face_create(const MpFaceLandmarkerOptions* opts, MpFaceCtx** out) 
   return 0;
 }
 
-static int rt_face_detect(MpFaceCtx* ctx, const MpImage* img, int64_t ts_us, MpFaceResult* out) {
-  if (!ctx || !ctx->landmarker || !out) return -1;
+static int rt_face_detect(MpFaceCtx *ctx, const MpImage *img, int64_t ts_us,
+                          MpFaceResult *out) {
+  if (!ctx || !ctx->landmarker || !out)
+    return -1;
 
   // Initialize output
   out->faces = nullptr;
@@ -130,55 +154,68 @@ static int rt_face_detect(MpFaceCtx* ctx, const MpImage* img, int64_t ts_us, MpF
 
   // Convert input to MediaPipe Image
   std::shared_ptr<ImageFrame> frame_ptr = make_imageframe_from_mp(img);
-  if (!frame_ptr) return -3;
+  if (!frame_ptr)
+    return -3;
 
   mediapipe::Image mp_image(frame_ptr);
 
-  // MediaPipe VIDEO mode expects timestamps in milliseconds.
+  // MediaPipe LIVE_STREAM mode expects timestamps in milliseconds.
   const int64_t ts_ms = (ts_us <= 0) ? 0 : (ts_us / 1000);
 
-  // Namespace aliases (these are namespaces, not types)
-  namespace mp_tasks = ::mediapipe::tasks;
-  namespace mp_face  = ::mediapipe::tasks::vision::face_landmarker;
+  {
+    std::lock_guard<std::mutex> lock(ctx->mutex);
+    ctx->result_ready = false;
+  }
 
-  absl::StatusOr<mp_face::FaceLandmarkerResult> res_or =
-      ctx->landmarker->DetectForVideo(mp_image, ts_ms);
-
-  if (!res_or.ok()) {
-    // Return 0 faces on failure, but keep the timestamp we were given.
+  absl::Status status = ctx->landmarker->DetectAsync(mp_image, ts_ms);
+  if (!status.ok()) {
     out->faces = nullptr;
     out->faces_count = 0;
     out->timestamp_us = ts_us;
     return 0;
   }
 
-  const mp_face::FaceLandmarkerResult& res = res_or.value();
+  std::unique_lock<std::mutex> lock(ctx->mutex);
+  ctx->cv.wait(lock, [&ctx]() { return ctx->result_ready; });
+  auto res_or = std::move(ctx->pending_result);
+  ctx->result_ready = false;
+  lock.unlock();
+
+  if (!res_or.ok()) {
+    out->faces = nullptr;
+    out->faces_count = 0;
+    out->timestamp_us = ts_us;
+    return 0;
+  }
+
+  const mp_face::FaceLandmarkerResult &res = res_or.value();
 
   // Allocate faces array
   const int F = static_cast<int>(res.face_landmarks.size());
-  MpFace* faces = nullptr;
+  MpFace *faces = nullptr;
   if (F > 0) {
-    faces = static_cast<MpFace*>(malloc(sizeof(MpFace) * F));
-    if (!faces) return -2;
+    faces = static_cast<MpFace *>(malloc(sizeof(MpFace) * F));
+    if (!faces)
+      return -2;
     std::memset(faces, 0, sizeof(MpFace) * F);
   }
 
   // Copy landmarks for each face
   for (int fi = 0; fi < F; ++fi) {
     // NormalizedLandmarks is a struct with a .landmarks vector
-    const auto& lmks_struct = res.face_landmarks[fi];
-    const std::vector<mp_tasks::components::containers::NormalizedLandmark>& pts_vec =
-        lmks_struct.landmarks;
+    const auto &lmks_struct = res.face_landmarks[fi];
+    const std::vector<mp_tasks::components::containers::NormalizedLandmark>
+        &pts_vec = lmks_struct.landmarks;
 
     const int N = static_cast<int>(pts_vec.size());
-    MpLandmark* pts = nullptr;
+    MpLandmark *pts = nullptr;
 
     if (N > 0) {
-      pts = static_cast<MpLandmark*>(malloc(sizeof(MpLandmark) * N));
+      pts = static_cast<MpLandmark *>(malloc(sizeof(MpLandmark) * N));
       if (!pts) {
         // Clean up what we already allocated for earlier faces
         for (int j = 0; j < fi; ++j) {
-          free(const_cast<MpLandmark*>(faces[j].landmarks));
+          free(const_cast<MpLandmark *>(faces[j].landmarks));
         }
         free(faces);
         return -2;
@@ -190,24 +227,21 @@ static int rt_face_detect(MpFaceCtx* ctx, const MpImage* img, int64_t ts_us, MpF
       }
     }
 
-    faces[fi].landmarks       = pts;
+    faces[fi].landmarks = pts;
     faces[fi].landmarks_count = N;
 
     // blendshapes/pose remain zero unless you enabled them in options elsewhere
   }
 
-  out->faces        = faces;
-  out->faces_count  = F;
+  out->faces = faces;
+  out->faces_count = F;
   out->timestamp_us = ts_us;
   return 0;
 }
 
+static void rt_face_free_result(MpFaceResult *out) { free_result_owned(out); }
 
-static void rt_face_free_result(MpFaceResult* out) {
-  free_result_owned(out);
-}
-
-static void rt_face_close(MpFaceCtx** pctx) {
+static void rt_face_close(MpFaceCtx **pctx) {
   if (pctx && *pctx) {
     delete *pctx;
     *pctx = nullptr;
@@ -216,27 +250,38 @@ static void rt_face_close(MpFaceCtx** pctx) {
 
 // ---------- API table ----------
 static const MpRuntimeApi g_api = {
-  /*api_version=*/MP_RUNTIME_API_VERSION,
-  /*runtime_version=*/rt_version,
-  /*runtime_build=*/rt_build,
-  /*face_create=*/rt_face_create,
-  /*face_detect=*/rt_face_detect,
-  /*face_free_result=*/rt_face_free_result,
-  /*face_close=*/rt_face_close,
+    /*api_version=*/MP_RUNTIME_API_VERSION,
+    /*runtime_version=*/rt_version,
+    /*runtime_build=*/rt_build,
+    /*face_create=*/rt_face_create,
+    /*face_detect=*/rt_face_detect,
+    /*face_free_result=*/rt_face_free_result,
+    /*face_close=*/rt_face_close,
 };
 
-extern "C" const MpRuntimeApi* mp_runtime_get_api(void) {
-  return &g_api;
-}
+extern "C" const MpRuntimeApi *mp_runtime_get_api(void) { return &g_api; }
 
 // Optional flat C exports (aliases)
-extern "C" int         mp_runtime_version(void) { return rt_version(); }
-extern "C" const char* mp_runtime_build(void)   { return rt_build(); }
-extern "C" int   mp_face_landmarker_create(const MpFaceLandmarkerOptions* o, MpFaceCtx** c) { return rt_face_create(o, c); }
-extern "C" int   mp_face_landmarker_detect(MpFaceCtx* c, const MpImage* i, int64_t t, MpFaceResult* r) { return rt_face_detect(c, i, t, r); }
-extern "C" void  mp_face_landmarker_free_result(MpFaceResult* r) { rt_face_free_result(r); }
-extern "C" void  mp_face_landmarker_close(MpFaceCtx** c) { rt_face_close(c); }
-extern "C" int   face_create(const MpFaceLandmarkerOptions* o, MpFaceCtx** c) { return rt_face_create(o, c); }
-extern "C" int   face_detect(MpFaceCtx* c, const MpImage* i, int64_t t, MpFaceResult* r) { return rt_face_detect(c, i, t, r); }
-extern "C" void  face_free_result(MpFaceResult* r) { rt_face_free_result(r); }
-extern "C" void  face_close(MpFaceCtx** c) { rt_face_close(c); }
+extern "C" int mp_runtime_version(void) { return rt_version(); }
+extern "C" const char *mp_runtime_build(void) { return rt_build(); }
+extern "C" int mp_face_landmarker_create(const MpFaceLandmarkerOptions *o,
+                                         MpFaceCtx **c) {
+  return rt_face_create(o, c);
+}
+extern "C" int mp_face_landmarker_detect(MpFaceCtx *c, const MpImage *i,
+                                         int64_t t, MpFaceResult *r) {
+  return rt_face_detect(c, i, t, r);
+}
+extern "C" void mp_face_landmarker_free_result(MpFaceResult *r) {
+  rt_face_free_result(r);
+}
+extern "C" void mp_face_landmarker_close(MpFaceCtx **c) { rt_face_close(c); }
+extern "C" int face_create(const MpFaceLandmarkerOptions *o, MpFaceCtx **c) {
+  return rt_face_create(o, c);
+}
+extern "C" int face_detect(MpFaceCtx *c, const MpImage *i, int64_t t,
+                           MpFaceResult *r) {
+  return rt_face_detect(c, i, t, r);
+}
+extern "C" void face_free_result(MpFaceResult *r) { rt_face_free_result(r); }
+extern "C" void face_close(MpFaceCtx **c) { rt_face_close(c); }


### PR DESCRIPTION
## Summary
- switch face landmarker runtime to MediaPipe LIVE_STREAM mode
- use async DetectAsync with callback and mutex to fetch results

## Testing
- `g++ -std=c++17 -c gstshared/mp_runtime.cc -I./gstshared -O2` *(fails: absl/status/statusor.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a60117d4832c99a3226ada2e3731