### PR TITLE
Hide imgwarp symbols and exclude lib objects

### DIFF
--- a/gstmozzamp/BUILD
+++ b/gstmozzamp/BUILD
@@ -19,6 +19,7 @@ cc_library(
     copts = [
         "-fPIC",
         "-I/usr/include/opencv4",
+        "-fvisibility=hidden",
     ],
     # Do NOT put linkopts here; keep them only on the final binary.
     alwayslink = True,   # <---- important
@@ -62,6 +63,7 @@ cc_binary(
     linkopts = [
         "-Wl,-z,defs",           # <---- fail at link time if anything is undefined
         "-Wl,--no-as-needed",    # <---- prevents ld from dropping needed libs
+        "-Wl,--exclude-libs,ALL",
         "-ldl",
         "-lopencv_core",
         "-lopencv_imgproc",


### PR DESCRIPTION
## Summary
- hide imgwarp symbols by compiling with hidden visibility
- prevent imgwarp objects from exporting via link opts

## Testing
- `bazel build //gstmozzamp:libgstmozzamp.so //gstfacelandmarks:libgstfacelandmarks.so` *(fails: could not download Bazel; Forbidden)*
- `GST_PLUGIN_PATH=bazel-bin/gstmozzamp gst-inspect-1.0 mozza_mp` *(fails: command not found: gst-inspect-1.0)*

------
https://chatgpt.com/codex/tasks/task_e_68a59d0e4f1c832ca63418796ad0ae1d