### PR TITLE
Namespace imgwarp utilities to avoid plugin conflicts

### DIFF
--- a/gstmozzamp/gstmozzamp.cpp
+++ b/gstmozzamp/gstmozzamp.cpp
@@ -74,7 +74,7 @@ struct _GstMozzaMp {
   // runtime + helpers
   MpFaceCtx* mp_ctx;
   std::optional<Deformations> dfm;
-  std::unique_ptr<ImgWarp_MLS_Rigid> mls;
+  std::unique_ptr<mp_imgwarp::ImgWarp_MLS_Rigid> mls;
 
   // stats
   guint64 frame_count;
@@ -295,7 +295,7 @@ static gboolean gst_mozza_mp_start(GstBaseTransform* base) {
   GST_INFO_OBJECT(self, "mp_face_landmarker created in %lld ms (delegate=%s, threads=%d)",
                   (long long)ms, opts.delegate, opts.num_threads);
 
-  self->mls = std::make_unique<ImgWarp_MLS_Rigid>();
+  self->mls = std::make_unique<mp_imgwarp::ImgWarp_MLS_Rigid>();
   self->mls->gridSize = 5;
   self->mls->preScale = true;
   self->mls->alpha    = 1.4;

--- a/imgwarp/delaunay.h
+++ b/imgwarp/delaunay.h
@@ -11,6 +11,9 @@
 #include <algorithm>
 #include <cstdlib>
 #include <vector>
+
+namespace mp_imgwarp {
+
 using cv::Point_;
 using std::vector;
 
@@ -36,4 +39,6 @@ vector<Triangle> delaunayDiv(const vector<Point_<T> > &vP, cv::Rect boundRect) {
     }
     return output;
 }
+
+}  // namespace mp_imgwarp
 

--- a/imgwarp/imgwarp_mls.cpp
+++ b/imgwarp/imgwarp_mls.cpp
@@ -4,6 +4,8 @@
 #include <cmath>
 #include <limits>
 
+namespace mp_imgwarp {
+
 using cv::Vec3b;
 using cv::Vec4b;
 
@@ -191,3 +193,5 @@ Mat ImgWarp_MLS::genNewImg(const Mat &oriImg, double transRatio) {
         }
     return newImg;
 }
+
+}  // namespace mp_imgwarp

--- a/imgwarp/imgwarp_mls.h
+++ b/imgwarp/imgwarp_mls.h
@@ -4,6 +4,8 @@
 #include "opencv2/opencv.hpp"
 #include <vector>
 
+namespace mp_imgwarp {
+
 using std::vector;
 using cv::Mat;
 using cv::Mat_;
@@ -91,5 +93,7 @@ inline void ImgWarp_MLS::setSrcPoints(const vector<Point_<float> > &qsrc) {
     newDotL.clear(); newDotL.reserve(nPoint);
     for (size_t i = 0; i < qsrc.size(); ++i) newDotL.push_back(qsrc[i]);
 }
+
+}  // namespace mp_imgwarp
 
 #endif // IMGTRANS_MLS_H

--- a/imgwarp/imgwarp_mls_rigid.cpp
+++ b/imgwarp/imgwarp_mls_rigid.cpp
@@ -3,6 +3,8 @@
 #include <cmath>
 #include <limits>
 
+namespace mp_imgwarp {
+
 static inline bool IMGWARP_DIAG() {
   static int on = -1;
   if (on == -1) {
@@ -151,4 +153,6 @@ void ImgWarp_MLS_Rigid::calcDelta() {
         for (i = 0; i < nPoint; ++i) newDotL[i] *= ratio; // restore
     }
 }
+
+}  // namespace mp_imgwarp
 

--- a/imgwarp/imgwarp_mls_rigid.h
+++ b/imgwarp/imgwarp_mls_rigid.h
@@ -19,8 +19,10 @@
 #include "imgwarp_mls.h"
 #include "opencv2/opencv.hpp"
 #include <vector>
-using std::vector;
 
+namespace mp_imgwarp {
+
+using std::vector;
 using cv::Mat;
 using cv::Mat_;
 using cv::Point_;
@@ -30,8 +32,7 @@ using cv::Point_;
  * It will try to keep the image rigid. You can set preScale if you
  * can accept uniform transform.
  */
-class ImgWarp_MLS_Rigid : public ImgWarp_MLS
-{
+class ImgWarp_MLS_Rigid : public ImgWarp_MLS {
 public:
     //! Whether do unify scale on the points before deformation
     bool preScale;
@@ -39,5 +40,7 @@ public:
     ImgWarp_MLS_Rigid();
     void calcDelta();
 };
+
+}  // namespace mp_imgwarp
 
 #endif // IMGTRANS_MLS_RIGID_H

--- a/imgwarp/imgwarp_mls_similarity.cpp
+++ b/imgwarp/imgwarp_mls_similarity.cpp
@@ -16,6 +16,8 @@
 
 #include "imgwarp_mls_similarity.h"
 
+namespace mp_imgwarp {
+
 void ImgWarp_MLS_Similarity::calcDelta() {
     int i, j, k;
 
@@ -103,3 +105,5 @@ void ImgWarp_MLS_Similarity::calcDelta() {
 
     delete[] w;
 }
+
+}  // namespace mp_imgwarp

--- a/imgwarp/imgwarp_mls_similarity.h
+++ b/imgwarp/imgwarp_mls_similarity.h
@@ -19,8 +19,10 @@
 #include "imgwarp_mls.h"
 #include "opencv2/opencv.hpp"
 #include <vector>
-using std::vector;
 
+namespace mp_imgwarp {
+
+using std::vector;
 using cv::Mat;
 using cv::Mat_;
 using cv::Point_;
@@ -30,5 +32,7 @@ class ImgWarp_MLS_Similarity : public ImgWarp_MLS {
    public:
     void calcDelta();
 };
+
+}  // namespace mp_imgwarp
 
 #endif  // IMGTRANS_MLS_SIMILARITY_H

--- a/imgwarp/imgwarp_piecewiseaffine.cpp
+++ b/imgwarp/imgwarp_piecewiseaffine.cpp
@@ -1,13 +1,15 @@
 #include "imgwarp_piecewiseaffine.h"
 #include "delaunay.h"
 
+namespace mp_imgwarp {
+
 using cv::Point2d;
 
-ImgWarp_PieceWiseAffine::ImgWarp_PieceWiseAffine(void) {
+ImgWarp_PieceWiseAffine::ImgWarp_PieceWiseAffine() {
     backGroundFillAlg = BGNone;
 }
 
-ImgWarp_PieceWiseAffine::~ImgWarp_PieceWiseAffine(void) {}
+ImgWarp_PieceWiseAffine::~ImgWarp_PieceWiseAffine() {}
 
 Point_<double> ImgWarp_PieceWiseAffine::getMLSDelta(int x, int y) {
     static Point_<double> swq, qstar, newP, tmpP;
@@ -108,13 +110,13 @@ void ImgWarp_PieceWiseAffine::calcDelta() {
         oL1.push_back(Point2d(tarW - 1, tarH - 1));
     }
     // In order preserv the background
-    V = ::delaunayDiv(oL1, boundRect);
+    V = delaunayDiv(oL1, boundRect);
 
     // Note: the following code requires highgui. Skipping them.
     //     vector< TriangleInID > Vt;
     // //     vector< Triangle >::iterator it;
     // //     cv::Rect_<int> boundRect(0, 0, tarW, tarH);
-    //     Vt = ::delaunayDivInID(oldDotL, boundRect);
+    //     Vt = delaunayDivInID(oldDotL, boundRect);
     //Mat_<uchar> imgTmp = Mat_<uchar>::zeros(tarH, tarW);
     //for (it = V.begin(); it != V.end(); it++) {
         //cv::line(imgTmp, it->v[0], it->v[1], 255, 1, cv::LINE_AA);
@@ -176,3 +178,5 @@ void ImgWarp_PieceWiseAffine::calcDelta() {
         }
     }
 }
+
+}  // namespace mp_imgwarp

--- a/imgwarp/imgwarp_piecewiseaffine.h
+++ b/imgwarp/imgwarp_piecewiseaffine.h
@@ -3,9 +3,9 @@
 
 #include "imgwarp_mls.h"
 
-class ImgWarp_PieceWiseAffine :
-	public ImgWarp_MLS
-{
+namespace mp_imgwarp {
+
+class ImgWarp_PieceWiseAffine : public ImgWarp_MLS {
 public:
     //! How to deal with the background.
     /*!
@@ -14,12 +14,13 @@ public:
         BGPieceWise: Use the same scheme for the background.
     */
     enum BGFill {
-			BGNone, //! No background is reserved.
-            BGMLS,  //! Use MLS to deal with the background.
-			BGPieceWise}; //! Use the same scheme for the background.
-    
-	ImgWarp_PieceWiseAffine(void);
-	~ImgWarp_PieceWiseAffine(void);
+        BGNone,      //! No background is reserved.
+        BGMLS,       //! Use MLS to deal with the background.
+        BGPieceWise  //! Use the same scheme for the background.
+    };
+
+    ImgWarp_PieceWiseAffine();
+    ~ImgWarp_PieceWiseAffine();
 
     void calcDelta();
     BGFill backGroundFillAlg;
@@ -27,4 +28,6 @@ private:
     Point_<double> getMLSDelta(int x, int y);
 };
 
-#endif //IMGTRANSPIECEWISEAFFINE_H
+}  // namespace mp_imgwarp
+
+#endif // IMGTRANSPIECEWISEAFFINE_H


### PR DESCRIPTION
## Summary
- Wrap all imgwarp headers and sources in the new `mp_imgwarp` namespace
- Update gstmozzamp plugin to reference namespaced image-warping utilities

## Testing
- `g++ -c imgwarp/imgwarp_mls.cpp -std=c++17` *(fails: opencv2/opencv.hpp: No such file or directory)*
- `g++ -c gstmozzamp/gstmozzamp.cpp -std=c++17 $(pkg-config --cflags gstreamer-1.0)` *(fails: Package 'gstreamer-1.0' not found)*
- `sudo apt-get update` *(fails: 403 Forbidden; unable to install missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68a59d12d184832cb17df23685e57f66