### PR TITLE
Fix finalize reference in gstfacelandmarks

### DIFF
--- a/gstfacelandmarks/gstfacelandmarks.cpp
+++ b/gstfacelandmarks/gstfacelandmarks.cpp
@@ -58,6 +58,8 @@ static GstStaticPadTemplate src_template  = GST_STATIC_PAD_TEMPLATE(
 
 G_DEFINE_TYPE(GstFaceLandmarks, gst_face_landmarks, GST_TYPE_VIDEO_FILTER)
 
+static void gst_face_landmarks_finalize(GObject* object);
+
 // ── RGBA overlay helpers ─────────────────────────────────────────────────────
 static inline void put_px(uint8_t* p, uint8_t r, uint8_t g, uint8_t b, uint8_t a) {
   const uint8_t dr = p[0], dg = p[1], db = p[2], da = p[3];


### PR DESCRIPTION
## Summary
- declare `gst_face_landmarks_finalize` before use in class init to fix compilation error

## Testing
- `bazel build //gstfacelandmarks:libgstfacelandmarks.so` *(fails: could not download Bazel: could not resolve version 'latest' due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a6cd739d04832ca6375854ec440404