### PR TITLE
Add per-group ROI warp option to mozza_mp

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ not yet functional and requires more work. We currently recommend keeping
 | `alpha` | float [-10..10] | 1.0 | Smile intensity multiplier (negative values frown). |
 | `mls-alpha` | float | 1.4 | Rigidity parameter for MLS warping. |
 | `mls-grid` | int | 5 | MLS grid size in pixels (smaller = denser). |
+| `warp-mode` | string | global | MLS warp strategy: `global` or `per-group-roi`. |
+| `roi-pad` | int [0..200] | 24 | Padding around group ROI when `warp-mode=per-group-roi` (pixels). |
 | `overlay` | boolean | false | Draw source/destination control points and vectors. |
 | `drop` | boolean | false | Drop frame when no face is detected. |
 | `show-landmarks` | boolean | false | Draw all detected landmarks even without a DFM. |

--- a/gstmozzamp/deform_utils.hpp
+++ b/gstmozzamp/deform_utils.hpp
@@ -3,10 +3,17 @@
 #include <opencv2/core.hpp>
 #include <vector>
 #include "dfm.hpp"
+#include "imgwarp/imgwarp_mls_rigid.h"
 
 // Build per-group src/dst point sets according to DFM rules
 void build_groups_from_dfm(const Deformations& dfm,
                            const std::vector<cv::Point2f>& L, float alpha,
                            std::vector<std::vector<cv::Point2f>>& srcGroups,
                            std::vector<std::vector<cv::Point2f>>& dstGroups);
+
+// Apply MLS on a local ROI (in-place on RGBA frame)
+void compute_MLS_on_ROI(cv::Mat& imgRGBA, mp_imgwarp::ImgWarp_MLS_Rigid& mls,
+                        const std::vector<cv::Point2f>& src,
+                        const std::vector<cv::Point2f>& dst,
+                        int pad);
 


### PR DESCRIPTION
## Summary
- allow mozza_mp to warp each DFM group in its own ROI or combine them globally
- add `warp-mode` (global/per-group-roi) and `roi-pad` properties
- document new properties

## Testing
- `bazel build //gstmozzamp:libgstmozzamp.so` *(fails: could not download Bazel, Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_68a747f850f8832ca4d4423ac4f9e9a9